### PR TITLE
Make tilemancer work on a duplicate of the image

### DIFF
--- a/tilemancer.scm
+++ b/tilemancer.scm
@@ -1,5 +1,7 @@
 (define (tilemancer image drawable option)
-  (let* ((width (car (gimp-image-width image)))
+  (let* (
+    (image (car (gimp-image-duplicate image)))     
+    (width (car (gimp-image-width image)))
     (height (car (gimp-image-height image)))
     (layers (gimp-image-get-layers image))
     (num-layers (car layers))
@@ -10,6 +12,7 @@
       (gimp-image-resize-to-layers image)
       (gimp-image-merge-visible-layers image 1)
       (gimp-image-grid-set-spacing image width height)
+      (gimp-display-new image)
       (gimp-displays-flush))))
 
 (define (sheeterize-square image item-vect framesize)


### PR DESCRIPTION
In a recent Reddit thread - see https://www.reddit.com/r/GIMP/comments/vcm6l0/how_do_i_make_scriptfu_create_and_open_copy_of/ - user TheCrystalEnds asked about how to make the tilemancer script work on a duplicate of the current image, instead of modifying the original image.

This can be done with two simple changes to the current script - that is, using gimp-image-duplicate to redefine the image variable at the very start of the script, and then using gimp-display-new to give the the new image a display and make it visible in the user interface. 

Overall, this seems to be the preferable approach in general, as modifying the existing image bears the danger of the users overwriting said original files by accident.