### PR TITLE
Add optional spacing between tiles and fix broken "One row per layer group" mode

### DIFF
--- a/tilemancer.scm
+++ b/tilemancer.scm
@@ -34,17 +34,19 @@
   )
 )
 
-(define (sheeterize-group image item-vect framesize row)
+(define (sheeterize-group image item-vect framesize row spacing)
   (let* ((width (car (gimp-image-width image)))
     (height (car (gimp-image-height image)))
     (cols (vector-length item-vect))) 
-    (do ((i 0 (+ i 1))) 
-      ((= i cols)) 
+    (do ((i 0 (+ i 1))) ((= i cols)) 
       (let* ((current-item (vector-ref item-vect i))
-        (xpos (* (- cols 1 i) (car framesize))))
-        (if (= 0 (car (gimp-item-is-group current-item)))
-          (gimp-layer-translate current-item xpos (* (- row 1) (cdr framesize)))
-          (sheeterize-group image (cadr (gimp-item-get-children current-item)) framesize (+ 1 row)))))))
+        (xpos (* (- cols 1 i) (+ spacing (car framesize)))))
+        (if 
+            (= 0 (car (gimp-item-is-group current-item)))
+            ; if this particular item is not group, print it on current row
+            (gimp-layer-translate current-item xpos (* row (+ spacing (cdr framesize))))
+            ; if it is group, recurse and use current item index as row index
+            (sheeterize-group image (cadr (gimp-item-get-children current-item)) framesize i spacing))))))
 
 (script-fu-register
     "tilemancer"

--- a/tilemancer.scm
+++ b/tilemancer.scm
@@ -7,7 +7,7 @@
     (num-layers (car layers))
     (layer-vect (cadr layers)))
     (cond ((= option 0) (sheeterize-square image layer-vect (cons width height) spacing))
-      ((= option 1) (sheeterize-group image layer-vect (cons width height) 0)))
+      ((= option 1) (sheeterize-group image layer-vect (cons width height) 0 spacing)))
     (begin
       (gimp-image-resize-to-layers image)
       (gimp-image-merge-visible-layers image 1)

--- a/tilemancer.scm
+++ b/tilemancer.scm
@@ -21,16 +21,16 @@
       (do ((j 0 (+ j 1))) ((= j side)) ; for j = 0; j < side; j++ 
         (let ((frame (- (vector-length item-vect) 1 (+ j (* i side)))))
           (if 
-			(>= frame 0) 
-			(gimp-layer-translate ; Copy input tile layer somewhere to output tileset
-				(vector-ref item-vect frame)
-				(* j (+ spacing (car framesize))) ; (framesize.x + spacing) * j
-				(* i (+ spacing (cdr framesize))) ; (framesize.y + spacing) * i
-			)
-		  )
-		)
-	  )
-	)
+            (>= frame 0) 
+            (gimp-layer-translate ; Copy input tile layer somewhere to output tileset
+                (vector-ref item-vect frame)
+                (* j (+ spacing (car framesize))) ; (framesize.x + spacing) * j
+                (* i (+ spacing (cdr framesize))) ; (framesize.y + spacing) * i
+            )
+          )
+        )
+      )
+    )
   )
 )
 
@@ -55,8 +55,8 @@
     "October 19, 2020"
     "*"
     SF-IMAGE      "Image"          0
-    SF-DRAWABLE      "Drawable"          0
-    SF-OPTION      "Shape" '("Square" "One row per layer group")
-	SF-VALUE       "Tile spacing amount (px)" "0"
+    SF-DRAWABLE   "Drawable"       0
+    SF-OPTION     "Shape" '("Square" "One row per layer group")
+    SF-VALUE      "Tile spacing amount (px)" "0"
 )
 (script-fu-menu-register "tilemancer" "<Image>/Filters/Animation")


### PR DESCRIPTION
Adding option to make some space between tiles to prevent color bleeding in certain rendering APIs (like HTML5 canvas). Free space is filled by transparent color. ~~Only adding this for Square mode because the other one seems to be broken (#3)~~

**UPDATE:** Didn't realize that updating master in my repo will update this PR as well so now it fixes my issue with basic layer grouping and adds spacing in both modes.

Resolves #3 (for the simple case as discussed in issue discussion)
Resolves #4 ~~(at least partially)~~